### PR TITLE
TSAS-8 - Permessi 0,88 giorni se stesso giorno

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -483,8 +483,8 @@ class HolidaysRequest(models.Model):
             employee = self.env['hr.employee'].browse(employee_id)
             if employee.tz:
                 tz = timezone(employee.tz)
-                date_from = date_from.replace(tzinfo=tz)
-                date_to = date_to.replace(tzinfo=tz)
+                date_from = tz.localize(datetime.combine(date_from, time.min))
+                date_to = tz.localize(datetime.combine(date_to, time.max))
             return employee.get_work_days_data(date_from, date_to)['days']
 
         today_hours = self.env.user.company_id.resource_calendar_id.get_work_hours_count(


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
When trying to add a day off for an employee, selecting 1 day will calculate 0,88 days instead
Desired behavior after PR is merged:
Adding a day off for an employee, should effectively add 1 day off, not 0,88



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
